### PR TITLE
Do not update IP on deletion

### DIFF
--- a/controllers/ip_controller.go
+++ b/controllers/ip_controller.go
@@ -69,11 +69,6 @@ func (r *IPReconciler) Reconcile(ctx context.Context, req ctrl.Request) (ctrl.Re
 			}
 
 			controllerutil.RemoveFinalizer(ip, CIPFinalizer)
-			err := r.Update(ctx, ip)
-			if err != nil {
-				log.Error(err, "unable to update ip resource on finalizer removal", "name", req.NamespacedName)
-				return ctrl.Result{}, err
-			}
 		}
 		return ctrl.Result{}, nil
 	}


### PR DESCRIPTION
The finalizer has already been removed, so the object is not existing

