### PR TITLE
Add dummy defaulter for each Webhook

### DIFF
--- a/api/ipam/v1alpha1/ip_webhook.go
+++ b/api/ipam/v1alpha1/ip_webhook.go
@@ -35,6 +35,12 @@ func (in *IP) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-ipam-metal-ironcore-dev-v1alpha1-ip,mutating=false,failurePolicy=fail,sideEffects=None,groups=ipam.metal.ironcore.dev,resources=ips,verbs=create;update;delete,versions=v1alpha1,name=vip.kb.io,admissionReviewVersions={v1,v1beta1}
 
+var _ webhook.Defaulter = &IP{}
+
+func (in *IP) Default() {
+	iplog.Info("default", "name", in.Name)
+}
+
 var _ webhook.Validator = &IP{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type

--- a/api/ipam/v1alpha1/network_webhook.go
+++ b/api/ipam/v1alpha1/network_webhook.go
@@ -30,6 +30,12 @@ func (in *Network) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-ipam-metal-ironcore-dev-v1alpha1-network,mutating=false,failurePolicy=fail,sideEffects=None,groups=ipam.metal.ironcore.dev,resources=networks,verbs=create;update;delete,versions=v1alpha1,name=vnetwork.kb.io,admissionReviewVersions={v1,v1beta1}
 
+var _ webhook.Defaulter = &Network{}
+
+func (in *Network) Default() {
+	iplog.Info("default", "name", in.Name)
+}
+
 var _ webhook.Validator = &Network{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type

--- a/api/ipam/v1alpha1/networkcounter_webhook.go
+++ b/api/ipam/v1alpha1/networkcounter_webhook.go
@@ -26,6 +26,12 @@ func (in *NetworkCounter) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-ipam-metal-ironcore-dev-v1alpha1-networkcounter,mutating=false,failurePolicy=fail,sideEffects=None,groups=ipam.metal.ironcore.dev,resources=networkcounters,verbs=create;update;delete,versions=v1alpha1,name=vnetworkcounter.kb.io,admissionReviewVersions={v1,v1beta1}
 
+var _ webhook.Defaulter = &NetworkCounter{}
+
+func (in *NetworkCounter) Default() {
+	iplog.Info("default", "name", in.Name)
+}
+
 var _ webhook.Validator = &NetworkCounter{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type

--- a/api/ipam/v1alpha1/subnet_webhook.go
+++ b/api/ipam/v1alpha1/subnet_webhook.go
@@ -83,6 +83,12 @@ func (in *Subnet) SetupWebhookWithManager(mgr ctrl.Manager) error {
 
 // +kubebuilder:webhook:path=/validate-ipam-metal-ironcore-dev-v1alpha1-subnet,mutating=false,failurePolicy=fail,sideEffects=None,groups=ipam.metal.ironcore.dev,resources=subnets,verbs=create;update;delete,versions=v1alpha1,name=vsubnet.kb.io,admissionReviewVersions={v1,v1beta1}
 
+var _ webhook.Defaulter = &Subnet{}
+
+func (in *Subnet) Default() {
+	iplog.Info("default", "name", in.Name)
+}
+
 var _ webhook.Validator = &Subnet{}
 
 // ValidateCreate implements webhook.Validator so a webhook will be registered for the type


### PR DESCRIPTION
Otherwise the controller complains:
`INFO    controller-runtime.builder    skip registering a mutating
webhook, object does not implement admission.Defaulter or WithDefaulter
wasn't called    {"GVK": "ipam.metal.ironcore.dev/v1alpha1, Kind=IP"}`
