### PR TITLE
Bump `controller-runtime` to v0.20.3

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -175,7 +175,7 @@ ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
 GOLANGCI_LINT_VERSION ?= v1.64
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.31.1
+GOIMPORTS_VERSION ?= v0.31.0
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= v0.3.0
 
 # curl retries

--- a/Makefile
+++ b/Makefile
@@ -173,9 +173,9 @@ CONTROLLER_TOOLS_VERSION ?= v0.17.1
 ENVTEST_VERSION ?= $(shell go list -m -f "{{ .Version }}" sigs.k8s.io/controller-runtime | awk -F'[v.]' '{printf "release-%d.%d", $$2, $$3}')
 #ENVTEST_K8S_VERSION is the version of Kubernetes to use for setting up ENVTEST binaries (i.e. 1.31)
 ENVTEST_K8S_VERSION ?= $(shell go list -m -f "{{ .Version }}" k8s.io/api | awk -F'[v.]' '{printf "1.%d", $$3}')
-GOLANGCI_LINT_VERSION ?= v1.63.4
+GOLANGCI_LINT_VERSION ?= v1.64
 ADDLICENSE_VERSION ?= v1.1.1
-GOIMPORTS_VERSION ?= v0.16.1
+GOIMPORTS_VERSION ?= v0.31.1
 GEN_CRD_API_REFERENCE_DOCS_VERSION ?= v0.3.0
 
 # curl retries


### PR DESCRIPTION
**What this PR does / why we need it**:

- Bump `controller-runtime` to v0.20.3
- Bump tooling versions

