### PR TITLE
Fix shaky tests

### DIFF
--- a/test/utils/utils.go
+++ b/test/utils/utils.go
@@ -184,7 +184,7 @@ func GetProjectDir() (string, error) {
 	if err != nil {
 		return wd, fmt.Errorf("failed to get current working directory: %w", err)
 	}
-	wd = strings.Replace(wd, "/test/e2e", "", -1)
+	wd = strings.ReplaceAll(wd, "/test/e2e", "")
 	return wd, nil
 }
 


### PR DESCRIPTION
Use komega's `Eventually()` to make sure the `Subnet`'s status was populated

Fixes https://github.com/ironcore-dev/ipam/issues/429